### PR TITLE
Add Disassembly to HASM CLI Tool

### DIFF
--- a/hasm/src/disassembler.rs
+++ b/hasm/src/disassembler.rs
@@ -1,0 +1,280 @@
+use common::Bytecode;
+use num_traits::{FromPrimitive, ToPrimitive};
+
+pub fn disassemble_program(code: &[u32]) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut i = 0;
+
+    while i < code.len() {
+        let opcode_val = code[i];
+        i += 1;
+
+        // convert the numeric opcode to bytecode enum
+        let opcode = match Bytecode::from_u32(opcode_val) {
+            Some(op) => op,
+            None => {
+                // fallback in case of unknown opcode
+                lines.push(format!("UNKNOWN_OPCODE {}", opcode_val));
+                continue;
+            }
+        };
+
+        match opcode {
+            // 0-operand instructions
+            Bytecode::Nop => {
+                lines.push("nop".to_string());
+            }
+            Bytecode::Halt => {
+                lines.push("halt".to_string());
+            }
+            Bytecode::Ret => {
+                lines.push("ret".to_string());
+            }
+            Bytecode::Syscall => {
+                lines.push("syscall".to_string());
+            }
+
+            // 2-operand instructions
+            Bytecode::LoadMemory => {
+                // load R{reg}, @{addr}
+                let reg = code.get(i).copied().unwrap_or_default();
+                let addr = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("load R{}, @{}", reg, addr));
+            }
+            Bytecode::LoadReg => {
+                // load R{reg_dst}, R{reg_src}
+                let dst = code.get(i).copied().unwrap_or_default();
+                let src = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("load R{}, R{}", dst, src));
+            }
+            Bytecode::LoadValue => {
+                // load R{reg}, {imm} (which can be integer bits or float bits)
+                let reg = code.get(i).copied().unwrap_or_default();
+                let imm = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+
+                lines.push(format!("load R{}, {}", reg, imm));
+            }
+            Bytecode::Store => {
+                // store @{addr}, R{reg}
+                let addr = code.get(i).copied().unwrap_or_default();
+                let reg = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("store @{}, R{}", addr, reg));
+            }
+            Bytecode::PushReg => {
+                // push R{reg}
+                let reg = code.get(i).copied().unwrap_or_default();
+                i += 1;
+                lines.push(format!("push R{}", reg));
+            }
+            Bytecode::PushValue => {
+                // push {imm}
+                let imm = code.get(i).copied().unwrap_or_default();
+                i += 1;
+                lines.push(format!("push {}", imm));
+            }
+            Bytecode::Pop => {
+                // pop R{reg}
+                let reg = code.get(i).copied().unwrap_or_default();
+                i += 1;
+                lines.push(format!("pop R{}", reg));
+            }
+
+            // Arithmetic ops (2 arguments)
+            Bytecode::Add => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("add R{}, R{}", r1, r2));
+            }
+            Bytecode::AddValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let imm = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("add R{}, {}", r1, imm));
+            }
+            Bytecode::Sub => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("sub R{}, R{}", r1, r2));
+            }
+            Bytecode::SubValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let imm = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("sub R{}, {}", r1, imm));
+            }
+            Bytecode::Mul => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("mul R{}, R{}", r1, r2));
+            }
+            Bytecode::MulValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let imm = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("mul R{}, {}", r1, imm));
+            }
+            Bytecode::Div => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("div R{}, R{}", r1, r2));
+            }
+            Bytecode::DivValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let imm = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("div R{}, {}", r1, imm));
+            }
+            Bytecode::Cmp => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("cmp R{}, R{}", r1, r2));
+            }
+            Bytecode::CmpValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let imm = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("cmp R{}, {}", r1, imm));
+            }
+
+            // Branching ops
+            Bytecode::Jmp
+            | Bytecode::Je
+            | Bytecode::Jne
+            | Bytecode::Jg
+            | Bytecode::Jge
+            | Bytecode::Jl
+            | Bytecode::Jle
+            | Bytecode::Ja
+            | Bytecode::Jae
+            | Bytecode::Jb
+            | Bytecode::Jbe
+            | Bytecode::Jc
+            | Bytecode::Jnc
+            | Bytecode::Jo
+            | Bytecode::Jno
+            | Bytecode::Js
+            | Bytecode::Jns
+            | Bytecode::Jxcz
+            | Bytecode::Call
+            | Bytecode::Inspect => {
+                let addr = code.get(i).copied().unwrap_or_default();
+                i += 1;
+                let mnemonic = match opcode {
+                    Bytecode::Jmp => "jmp",
+                    Bytecode::Je => "je",
+                    Bytecode::Jne => "jne",
+                    Bytecode::Jg => "jg",
+                    Bytecode::Jge => "jge",
+                    Bytecode::Jl => "jl",
+                    Bytecode::Jle => "jle",
+                    Bytecode::Ja => "ja",
+                    Bytecode::Jae => "jae",
+                    Bytecode::Jb => "jb",
+                    Bytecode::Jbe => "jbe",
+                    Bytecode::Jc => "jc",
+                    Bytecode::Jnc => "jnc",
+                    Bytecode::Jo => "jo",
+                    Bytecode::Jno => "jno",
+                    Bytecode::Js => "js",
+                    Bytecode::Jns => "jns",
+                    Bytecode::Jxcz => "jxcz",
+                    Bytecode::Call => "call",
+                    Bytecode::Inspect => "inspect",
+                    _ => unreachable!(),
+                };
+                lines.push(format!("{} @{}", mnemonic, addr));
+            }
+
+            Bytecode::LoadByte => {
+                let r = code.get(i).copied().unwrap_or_default();
+                let addr = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("loadbyte R{}, @{}", r, addr));
+            }
+            Bytecode::StoreByte => {
+                let addr = code.get(i).copied().unwrap_or_default();
+                let r = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("storebyte @{}, R{}", addr, r));
+            }
+
+            // Float ops
+            Bytecode::FAddValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("fadd R{}, R{}", r1, r2));
+            }
+            Bytecode::FAdd => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let bits = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                let float_val = f32::from_bits(bits);
+                lines.push(format!("fadd R{}, {}", r1, float_val));
+            }
+            Bytecode::FSubValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("fsub R{}, R{}", r1, r2));
+            }
+            Bytecode::FSub => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let bits = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                let float_val = f32::from_bits(bits);
+                lines.push(format!("fsub R{}, {}", r1, float_val));
+            }
+            Bytecode::FMulValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("fmul R{}, R{}", r1, r2));
+            }
+            Bytecode::FMul => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let bits = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                let float_val = f32::from_bits(bits);
+                lines.push(format!("fmul R{}, {}", r1, float_val));
+            }
+            Bytecode::FDivValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("fdiv R{}, R{}", r1, r2));
+            }
+            Bytecode::FDiv => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let bits = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                let float_val = f32::from_bits(bits);
+                lines.push(format!("fdiv R{}, {}", r1, float_val));
+            }
+            Bytecode::FCmpValue => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let r2 = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                lines.push(format!("fcmp R{}, R{}", r1, r2));
+            }
+            Bytecode::FCmp => {
+                let r1 = code.get(i).copied().unwrap_or_default();
+                let bits = code.get(i + 1).copied().unwrap_or_default();
+                i += 2;
+                let float_val = f32::from_bits(bits);
+                lines.push(format!("fcmp R{}, {}", r1, float_val));
+            }
+        }
+    }
+
+    lines
+}

--- a/hasm/src/lib.rs
+++ b/hasm/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod disassembler;
+
 use common::Bytecode;
 use num_traits::ToPrimitive;
 use std::collections::HashMap;

--- a/hasm/src/main.rs
+++ b/hasm/src/main.rs
@@ -1,25 +1,54 @@
-use std::{io::BufWriter, path::PathBuf};
-
-use byteorder::WriteBytesExt;
+use std::{fs::File, io::{BufReader, BufWriter}, path::PathBuf};
+use byteorder::{WriteBytesExt, ReadBytesExt, LittleEndian};
 use clap::Parser;
+use hasm::disassembler::disassemble_program;
 use hasm::assemble_program;
 
 #[derive(Parser)]
 struct Args {
     input: PathBuf,
     output: PathBuf,
+    #[clap(long, short)]
+    disassemble: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let Args { input, output } = Args::parse();
-    let program = std::fs::read_to_string(input)?;
+    let Args { input, output, disassemble } = Args::parse();
 
-    let code = assemble_program(&program)?;
-
-    let file = std::fs::File::create(output)?;
-    let mut reader = BufWriter::new(file);
-    for v in code {
-        reader.write_u32::<byteorder::LittleEndian>(v)?;
+    if disassemble {
+        let program = read_u32_values(&input)?;
+        let code = disassemble_program(&program);
+        let combined_code = code.join("\n");
+        std::fs::write(&output, combined_code)
+            .map_err(|e| format!("Failed to write output file '{}': {e}", output.display()))?;
+    } else {
+        let program = std::fs::read_to_string(&input)?;
+        let code = assemble_program(&program)?;
+        write_u32_values(&output, &code)?;
     }
+
+    Ok(())
+}
+
+fn read_u32_values(input: &PathBuf) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
+    let file = File::open(input)?;
+    let mut reader = BufReader::new(file);
+
+    let mut values = Vec::new();
+    while let Ok(value) = reader.read_u32::<LittleEndian>() {
+        values.push(value);
+    }
+
+    Ok(values)
+}
+
+fn write_u32_values(output: &PathBuf, values: &[u32]) -> Result<(), Box<dyn std::error::Error>> {
+    let file = File::create(output)?;
+    let mut writer = BufWriter::new(file);
+
+    for &value in values {
+        writer.write_u32::<LittleEndian>(value)?;
+    }
+
     Ok(())
 }


### PR DESCRIPTION
# Add Disassembly to HASM CLI Tool

## Description
This pull request introduces the following changes:

1. **Disassembly Functionality**:
   - Added the `disassemble_program` function to convert bytecode into human-readable assembly instructions.
   - Supports various instruction types (0-operand, 2-operand, branching, and float operations).
   - Includes fallback handling for unknown opcodes (`UNKNOWN_OPCODE`).

2. **Command-Line Integration**:
   - Added a `--disassemble` flag to the CLI to enable disassembling binary bytecode files.

3. **File Input/Output**:
   - Refactor: Added utility functions `read_u32_values` and `write_u32_values` to handle binary file operations.


## Changes
- Added `disassemble_program` to `hasm::disassembler`. (For future debugger support)
- Updated CLI to handle disassembly with the `--disassemble` flag.

## examples
### Disassemble a Bytecode File
```bash
cargo run -- --disassemble -i program.hbin -o program.hasm
```

### Assemble a Source File
```bash
cargo run -- -i program.hasm -o program.hbin
```

```asm
main:
  load R3, R1
  load R4, 3
  call @add_int
  store @1000, R2
  inspect @1000 ; debug
  halt ; main ended
add_int:
  store @1004, R3
  store @1008, R4
  load R5, @1004
  load R2, @1008
  add R2, R5
  ret
```

## To 

```asm
load R3, R1
load R4, 3
call @label_14
store @1000, R2
inspect @1000
halt
label_14:
  store @1004, R3
  store @1008, R4
  load R5, @1004
  load R2, @1008
  add R2, R5
  ret
```